### PR TITLE
New hosts with max auth tries for key auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -942,6 +942,21 @@ services:
       - "2224:22"
       - "60001-60010:60001-60010/udp"
 
+  mosh-key-auth-tries-1:
+    mem_limit: 64m
+    build:
+      context: .
+      dockerfile: mosh/Dockerfile
+    environment:
+      ADMIN: sa
+      CONFIG: sshd_config
+      PUB_KEY_NAME: id_rsa.pub
+      MAX_AUTH_TRIES: MaxAuthTries 1
+    restart: "unless-stopped"
+    ports:
+      - "22241:22"
+      - "60031-60040:60031-60040/udp"
+
   mosh-unstable:
     mem_limit: 64m
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1154,6 +1154,7 @@ services:
     restart: "unless-stopped"
     links:
       - chain2
+      - chain2-auth-tries-1
       - http-proxy-chain2
 
   chain2:
@@ -1164,6 +1165,20 @@ services:
       CONFIG: sshd_config
       PUB_KEY_NAME: id_rsa.pub
       PRIVATE_KEY_NAME: id_rsa1
+    restart: "unless-stopped"
+    links:
+      - chain3
+      - http-proxy-chain3
+
+  chain2-auth-tries-1:
+    mem_limit: 64m
+    build: .
+    environment:
+      ADMIN: chain2
+      CONFIG: sshd_config
+      PUB_KEY_NAME: id_rsa.pub
+      PRIVATE_KEY_NAME: id_rsa1
+      MAX_AUTH_TRIES: MaxAuthTries 1
     restart: "unless-stopped"
     links:
       - chain3

--- a/mosh/Dockerfile
+++ b/mosh/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
 RUN apt-get install -y mosh iproute2
 
 ADD mosh/entrypoint.sh /usr/bin/entrypoint.sh
-ADD mosh/sshd_config /etc/ssh/sshd_config
+ADD mosh/sshd_config /tmp/
 ADD keys /tmp/
 ADD zshrc /tmp/
 

--- a/mosh/entrypoint.sh
+++ b/mosh/entrypoint.sh
@@ -36,6 +36,8 @@ add_pass() {
     fi
 }
 
+envsubst < /tmp/$CONFIG > "/etc/ssh/sshd_config"
+
 mkdir /var/run/sshd
 
 create_user $ADMIN

--- a/mosh/sshd_config
+++ b/mosh/sshd_config
@@ -6,3 +6,4 @@ AuthorizedKeysFile .ssh/authorized_keys
 LogLevel DEBUG3
 SyslogFacility AUTH
 PrintLastLog no
+${MAX_AUTH_TRIES}

--- a/sshd_configs_raw/sshd_config
+++ b/sshd_configs_raw/sshd_config
@@ -8,3 +8,4 @@ SyslogFacility AUTHPRIV
 Subsystem sftp /usr/lib/openssh/sftp-server -l DEBUG3
 PrintLastLog no
 AcceptEnv LANG LC_*
+${MAX_AUTH_TRIES}


### PR DESCRIPTION
## Description of the change

Add a new host with MaxAuthTries for key-based authentication:
- Host-chain connection.
- Connection with `Mosh`.

## Type of change

- [x] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [ ] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.
