### PR TITLE
Add telnet host with double echo issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -959,6 +959,18 @@ services:
     ports:
       - "2216:23"
 
+  telnet-echo-issue:
+    mem_limit: 64m
+    build:
+      context: .
+      dockerfile: telnet-echo-issue/Dockerfile
+    environment:
+      ADMIN: sa
+      ADMIN_PASS: pass
+    restart: "unless-stopped"
+    ports:
+      - "22103:23"
+
   mosh-key:
     mem_limit: 64m
     build:

--- a/telnet-echo-issue/Dockerfile
+++ b/telnet-echo-issue/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:22.04
+
+RUN apt-get update -y && apt-get install -y locales && \
+  locale-gen en_US.UTF-8 && update-locale LC_ALL="en_US.UTF-8"
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && apt-get upgrade -y && \
+  apt-get install -y xinetd gettext-base syslog-ng \
+    tmux byobu emacs vim mc htop curl nano \
+    bb cmatrix libaa-bin \
+    zsh git \
+    build-essential autoconf automake libtool texinfo libncurses-dev libreadline-dev \
+    bison help2man
+
+# Clone inetutils and build telnetd from source with patch
+WORKDIR /tmp/inetutils-build
+RUN git clone https://git.savannah.gnu.org/git/inetutils.git . && \
+  ./bootstrap && \
+  ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc
+
+# Apply patch to disable IAC WILL ECHO
+COPY telnet-echo-issue/apply-patch.sh /tmp/
+RUN chmod +x /tmp/apply-patch.sh && /tmp/apply-patch.sh
+
+# Build and install telnetd (need to build dependencies first)
+RUN cd /tmp/inetutils-build && \
+  make -C lib && \
+  make -C libinetutils && \
+  make -C libtelnet && \
+  make -C telnetd && \
+  make -C telnetd install && \
+  ls -la /usr/libexec/telnetd
+
+# Ensure telnetd is named in.telnetd and in the expected location for xinetd
+RUN mv /usr/libexec/telnetd /usr/libexec/in.telnetd && \
+  ln -s /usr/libexec/in.telnetd /usr/sbin/in.telnetd && \
+  ls -la /usr/sbin/in.telnetd
+
+WORKDIR /
+
+ADD telnet-echo-issue/telnet /etc/xinetd.d/
+ADD telnet-echo-issue/entrypoint.sh /usr/bin/entrypoint.sh
+
+RUN chmod +x /usr/bin/entrypoint.sh
+
+ENTRYPOINT /usr/bin/entrypoint.sh

--- a/telnet-echo-issue/apply-patch.sh
+++ b/telnet-echo-issue/apply-patch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+cd /tmp/inetutils-build/telnetd
+
+# Replace send_will, send_do, and send_dont TELOPT_ECHO calls with empty statements
+# This prevents the server from sending WILL ECHO, DO ECHO, or DONT ECHO
+find . -name "*.c" -type f -exec sed -i \
+  's/send_will[[:space:]]*([^,]*TELOPT_ECHO[^)]*);/\/\* send_will TELOPT_ECHO disabled \*\/ ;/g' {} +
+
+find . -name "*.c" -type f -exec sed -i \
+  's/send_do[[:space:]]*([^,]*TELOPT_ECHO[^)]*);/\/\* send_do TELOPT_ECHO disabled \*\/ ;/g' {} +
+
+find . -name "*.c" -type f -exec sed -i \
+  's/send_dont[[:space:]]*([^,]*TELOPT_ECHO[^)]*);/\/\* send_dont TELOPT_ECHO disabled \*\/ ;/g' {} +
+
+echo "Patched telnetd to disable IAC WILL/DO/DONT ECHO"

--- a/telnet-echo-issue/entrypoint.sh
+++ b/telnet-echo-issue/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+groupadd remote
+useradd -s /bin/bash -d /home/$ADMIN -G remote -m $ADMIN
+echo "$ADMIN:$ADMIN_PASS" | chpasswd
+
+service xinetd start
+tail -f /dev/null

--- a/telnet-echo-issue/telnet
+++ b/telnet-echo-issue/telnet
@@ -1,0 +1,10 @@
+service telnet
+{
+        disable = no
+        flags           = REUSE
+        socket_type     = stream
+        wait            = no
+        user            = root
+        server          = /usr/sbin/in.telnetd
+        log_on_failure  += USERID
+}


### PR DESCRIPTION
## Description of the change

Added host that emulates non standard-compliant behaviour of some telnet servers, resulting in double echo

## Type of change

- [X] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [ ] Hotfix

## Reviewer's checklist

- [ ] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.
