### PR TITLE
fix: update contributing repo URL to termius org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Make sure you can connect to service you want:
 
 Push to your fork and [submit a pull request][pr].
 
-[pr]: https://github.com/Crystalnix/hosts-farm/compare/
+[pr]: https://github.com/termius/hosts-farm/compare/
 
 At this point you're waiting on us. We like to at least comment on pull requests
 within three business days (and, typically, one business day). We may suggest


### PR DESCRIPTION
## Summary
`CONTRIBUTING.md` still points contributors at `https://github.com/Crystalnix/hosts-farm/compare/` for opening pull requests, but the repository has since moved to the `termius` organization (`termius/hosts-farm`). GitHub currently follows the redirect, but the visible link and organization name in the docs are stale. Updated the PR link to the canonical `termius/hosts-farm` URL so contributors land on the right compare page directly.

## How to reproduce
1. Open `CONTRIBUTING.md` on `master`.
2. Scroll to the "submit a pull request" section — the `[pr]` reference link is `https://github.com/Crystalnix/hosts-farm/compare/`.
3. Compare with the repo's actual location: `https://github.com/termius/hosts-farm`.

## Test plan
- Read the updated `CONTRIBUTING.md` and confirm the `[pr]` reference now points at `https://github.com/termius/hosts-farm/compare/`.
- Click the "submit a pull request" link in the rendered Markdown and confirm it opens the compare page on `termius/hosts-farm` without going through a redirect.